### PR TITLE
♻️ Refactor : 로그인, 회원가입의 Dto를 RequestAuthDto로 수정

### DIFF
--- a/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
+++ b/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
@@ -2,8 +2,6 @@ package com.team6.todomateclone.member.controller;
 
 import com.team6.todomateclone.common.response.SuccessResponse;
 import com.team6.todomateclone.member.dto.RequestAuthMemberDto;
-import com.team6.todomateclone.member.dto.RequestLoginMemberDto;
-import com.team6.todomateclone.member.dto.RequestSignupMemberDto;
 import com.team6.todomateclone.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
+++ b/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
@@ -31,5 +31,4 @@ public class MemberAuthController {
         memberService.login(request, response);
         return new SuccessResponse<>("로그인 성공하였습니다.", null);
     }
-
 }

--- a/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
+++ b/src/main/java/com/team6/todomateclone/member/controller/MemberAuthController.java
@@ -1,6 +1,7 @@
 package com.team6.todomateclone.member.controller;
 
 import com.team6.todomateclone.common.response.SuccessResponse;
+import com.team6.todomateclone.member.dto.RequestAuthMemberDto;
 import com.team6.todomateclone.member.dto.RequestLoginMemberDto;
 import com.team6.todomateclone.member.dto.RequestSignupMemberDto;
 import com.team6.todomateclone.member.service.MemberService;
@@ -21,13 +22,14 @@ public class MemberAuthController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public SuccessResponse<Object> signup(@Valid @RequestBody RequestSignupMemberDto request){
+    public SuccessResponse<Object> signup(@Valid @RequestBody RequestAuthMemberDto request, HttpServletResponse response){
         memberService.signup(request);
+        memberService.login(request, response);
         return new SuccessResponse<>("회원가입 성공하였습니다.",null);
     }
 
     @PostMapping("/login")
-    public SuccessResponse<Object> login(@RequestBody RequestLoginMemberDto request, HttpServletResponse response) {
+    public SuccessResponse<Object> login(@RequestBody RequestAuthMemberDto request, HttpServletResponse response) {
         memberService.login(request, response);
         return new SuccessResponse<>("로그인 성공하였습니다.", null);
     }

--- a/src/main/java/com/team6/todomateclone/member/dto/RequestAuthMemberDto.java
+++ b/src/main/java/com/team6/todomateclone/member/dto/RequestAuthMemberDto.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Getter
-public class RequestSignupMemberDto {
+public class RequestAuthMemberDto {
     @NotBlank
     @Pattern(regexp = "^[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$", message = "이메일 형식이 올바르지 않습니다.")
     private String email;

--- a/src/main/java/com/team6/todomateclone/member/dto/RequestLoginMemberDto.java
+++ b/src/main/java/com/team6/todomateclone/member/dto/RequestLoginMemberDto.java
@@ -1,9 +1,0 @@
-package com.team6.todomateclone.member.dto;
-
-import lombok.Getter;
-
-@Getter
-public class RequestLoginMemberDto {
-    private String email;
-    private String password;
-}

--- a/src/main/java/com/team6/todomateclone/member/service/MemberService.java
+++ b/src/main/java/com/team6/todomateclone/member/service/MemberService.java
@@ -7,8 +7,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.team6.todomateclone.common.exception.CustomErrorCodeEnum;
 import com.team6.todomateclone.common.exception.CustomErrorException;
 import com.team6.todomateclone.common.jwt.JwtUtil;
-import com.team6.todomateclone.member.dto.RequestLoginMemberDto;
-import com.team6.todomateclone.member.dto.RequestSignupMemberDto;
+import com.team6.todomateclone.member.dto.RequestAuthMemberDto;
 import com.team6.todomateclone.member.dto.RequestUpdateInfoMemberDto;
 import com.team6.todomateclone.member.dto.ResponseInfoMemberDto;
 import com.team6.todomateclone.member.dto.ResponseUpdateImageMemberDto;
@@ -45,7 +44,7 @@ public class MemberService {
     /* 기본 이미지 url */
     private static final String defaultImage = "https://cdn.icon-icons.com/icons2/1875/PNG/512/user_120285.png";
 
-    public void signup(RequestSignupMemberDto request) {
+    public void signup(RequestAuthMemberDto request) {
         String email = request.getEmail();
         String password = passwordEncoder.encode(request.getPassword());
 
@@ -62,7 +61,7 @@ public class MemberService {
         tagRepository.save(tag);
     }
 
-    public void login(RequestLoginMemberDto request, HttpServletResponse response) {
+    public void login(RequestAuthMemberDto request, HttpServletResponse response) {
         Member member = checkEmail(request);
 
         if (!(passwordEncoder.matches(request.getPassword(), member.getPassword()))) {
@@ -127,7 +126,7 @@ public class MemberService {
     }
 
     // 유저 Email 존재 여부 확인 메서드
-    private Member checkEmail(RequestLoginMemberDto request) {
+    private Member checkEmail(RequestAuthMemberDto request) {
         return memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomErrorException(EMAIL_NOT_FOUND_MSG));
     }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
로그인, 회원가입의 Dto를 RequestAuthDto로 통일


## 작업사항
- 회원가입 시, 토큰을 받아오기 위해서 로그인, 회원가입 Dto를 RequestAuthDto 로 통일.
- signup 메서드를 실행한 뒤, login 메서드를 트랜잭션으로 처리해 토큰을 response로 넘겨준다.


## 변경로직
- RequestLoginDto, RequestSignupDto -> RequestAuthDto로 변경
- signup 메서드의 매개변수로 HttpServletResponse 추가
- checkEmail의 매개변수를 RequestAuthDto로 변경
