### PR TITLE
🐛 Fix: 태그 삭제 오류 수정

### DIFF
--- a/src/main/java/com/team6/todomateclone/tag/service/TagService.java
+++ b/src/main/java/com/team6/todomateclone/tag/service/TagService.java
@@ -77,7 +77,7 @@ public class TagService {
         // 태그가 하나라도 있으면 삭제 불가
         List<Tag> tagExist = tagRepository.findAll();
         if (tagExist.size()>1) {
-            todoRepository.deleteTodoByTag(tag);
+            todoRepository.deleteByTagId(tagId);
             tagRepository.deleteById(tagId);
         } else {
             throw new CustomErrorException(TAG_NOT_DELETE_MSG);

--- a/src/main/java/com/team6/todomateclone/todo/repository/TodoRepository.java
+++ b/src/main/java/com/team6/todomateclone/todo/repository/TodoRepository.java
@@ -20,5 +20,5 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     List<Todo> findAllByMemberIdAndTodoYearAndTodoMonth(Long memberId, Long todoYear, Long todoMonth);
 
-    void deleteTodoByTag(Tag tag);
+    void deleteByTagId(Long tagId);
 }


### PR DESCRIPTION
태그 삭제 시 관련된 투두들을 삭제할 때 연관관계 설정으로 인해 오류가 난 부분 수정

## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
태그 삭제 시에 안에 있는 투두들도 같이 삭제가 되도록 하는 로직에서 연관관계 설정이 단방향으로 설정이 되어있었기 때문에 Tag 에서 tagId로 변경


## 작업사항
            todoRepository.deleteByTagId(tagId);


## 변경로직
- 내용을 적어주세요.
